### PR TITLE
Add instructions to fix a clientsettings rendering issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ Netify is a debugging proxy that will allow you to intercept and mutate your req
 - Adding, replacing and removing response headers.
 - Replacing a response body with a text value, Base64, or file's content.
 - Cancel requests on the client.
+
+### FAQ
+Q. Netify shows a blank page when I open it, why is this happening?  
+A. This is sometimes caused by your "Cookies and other site data" being set too strict, you can add an exception for the extension:    
+
+1. Copy `chrome://settings/cookies?search=Sites+that+can+always+use+cookies` into the URL bar and press enter.    
+2. Scroll down until you find the words "Sites that can always use cookies" highlighted in yellow.  
+3. Click the "Add" button to the right of the highlighted words.  
+4. Paste the extension ID (`mdafhjaillpdogjdigdkmnoddeoegblj`) into the "site" text box in the popup, then click the add button.    
+
+If you still have netify open, right click the blank netify page and click "reload frame".    
+If you already closed netify, just re-open it.    
+The netify window should no longer give you a blank screen.    


### PR DESCRIPTION
Added a FAQ section
Added an FAQ item to provided an explanation and instructions to fix a "Cookies and other site data" settings issue that causes the whole netify devtools panel to fail to render.
When the "Cookies and other site data" global setting is set to "Block third-party cookies", it prevents netify from accessing "IndexedDB" 
The instructions given show the user how to add netify's extension ID as an exception to the "Block third-party cookies" (and site data) rule.
I tried adding "chrome-extension://mdafhjaillpdogjdigdkmnoddeoegblj" as the site URL, but it wouldn't allow the "chrome-extension://" URL prefix.

https://imgur.com/S9sfvnF shows the errors that netify gives off when it can't read or write cookies or other site data.
I got the image by opening a devtools window on the netify panel that failed to load using inspect, then going to the console of that devtools window to view errors given off by netify itself.