### PR TITLE
Trim Whitespaces in URL Filter 

### DIFF
--- a/src/components/forms/rule/RuleForm/deserializeRuleForm.ts
+++ b/src/components/forms/rule/RuleForm/deserializeRuleForm.ts
@@ -121,7 +121,7 @@ export function deserializeRuleForm(form: RuleFormSchema, id: string, active: bo
 		label,
 		active,
 		filter: {
-			url: filter.url,
+			url: filter.url.trim(),
 			resourceTypes: filter.resourceTypes,
 			methods: filter.methods,
 		},

--- a/src/components/forms/rule/RuleForm/serializeRuleForm.ts
+++ b/src/components/forms/rule/RuleForm/serializeRuleForm.ts
@@ -12,7 +12,7 @@ export function serializeRuleForm(rule: Rule) {
 	const value: RuleFormSchema = {
 		label,
 		filter: {
-			url: filter.url,
+			url: filter.url.trim(),
 			resourceTypes: filter.resourceTypes,
 			methods: filter.methods,
 		},


### PR DESCRIPTION
This pull request aims to enhance the URL filtering functionality by implementing whitespace trimming. The current implementation does not handle leading or trailing whitespaces in the URLs, which can lead to unexpected behavior and issues in certain scenarios.

To address this, the proposed changes include the following:

- Modify the URL filtering module to incorporate a whitespace trimming mechanism.

Benefits of this modification:
- Improved user experience: Trimming whitespaces from URLs will ensure that users' inputs are handled consistently, preventing potential errors due to unintentional spaces.
- Enhanced stability: By eliminating leading or trailing whitespaces, we can mitigate any unforeseen issues caused by inconsistent URL formatting.

The proposed code changes have been thoroughly tested and validated, ensuring that existing functionality remains unaffected. Additionally, the modifications are backward-compatible and do not introduce any breaking changes.

I kindly request your review and feedback on this pull request. Your input and suggestions are highly appreciated.