### PR TITLE
Add clone rule capability

### DIFF
--- a/src/components/forms/rule/RuleCompose/RuleCompose.tsx
+++ b/src/components/forms/rule/RuleCompose/RuleCompose.tsx
@@ -1,4 +1,5 @@
 import React, {memo, useMemo} from 'react';
+import {toJS} from 'mobx';
 import {RuleActionsType} from '@/constants/RuleActionsType';
 import {Rule, RuleInitialData} from '@/interfaces/rule';
 import {randomHex} from '@/helpers/random';
@@ -22,8 +23,20 @@ export const RuleCompose = memo<RuleComposeProps>((props) => {
 		rulesStore.closeCompose();
 	};
 
-	const ruleValue = useMemo<Rule>(
-		() => ({
+	const ruleValue = useMemo<Rule>(() => {
+		const cloneFrom = initialData?.cloneFrom;
+		if (cloneFrom) {
+			const plain = toJS(cloneFrom);
+			const label = plain.label !== undefined && plain.label !== '' ? `Copy of ${plain.label}` : 'Copied Rule';
+			return {
+				...plain,
+				id: randomHex(16),
+				active: true,
+				label,
+			};
+		}
+
+		return {
 			id: randomHex(16),
 			active: true,
 			filter: Object.assign(
@@ -45,9 +58,8 @@ export const RuleCompose = memo<RuleComposeProps>((props) => {
 					dropHeaders: [],
 				},
 			},
-		}),
-		[],
-	);
+		};
+	}, [initialData]);
 
 	return <RuleForm mode='create' initialRule={ruleValue} onSave={handleCreate} onCancel={handleClose} />;
 });

--- a/src/components/rules/RulesItemControls/RulesItemControls.tsx
+++ b/src/components/rules/RulesItemControls/RulesItemControls.tsx
@@ -1,7 +1,8 @@
 import React, {memo, useCallback} from 'react';
-import {TextButton} from '@/components/@common/buttons/TextButton';
 import {useStores} from '@/stores/useStores';
+import {TextButton} from '@/components/@common/buttons/TextButton';
 import AboveIcon from '@/assets/icons/above.svg';
+import AddIcon from '@/assets/icons/add.svg';
 import BelowIcon from '@/assets/icons/below.svg';
 import CheckActiveIcon from '@/assets/icons/check-active.svg';
 import CheckInactiveIcon from '@/assets/icons/check-inactive.svg';
@@ -27,16 +28,21 @@ export const RulesItemControls = memo<RulesItemControlsProps>((props) => {
 		onClose();
 	}, [ruleId]);
 
+	const handleClone = useCallback(() => {
+		rulesStore.showCloneCompose(ruleId);
+		onClose();
+	}, [ruleId]);
+
 	const handleActiveToggle = async () => {
 		rulesStore.updateRuleActive(ruleId, !ruleIsActive);
 	};
 
-	const handleMove = async (shift: 1 | -1) => {
+	const handleMove = async () => {
 		// TODO in future
 	};
 
-	const handleMoveAbove = () => handleMove(-1);
-	const handleMoveBelow = () => handleMove(1);
+	const handleMoveAbove = () => handleMove();
+	const handleMoveBelow = () => handleMove();
 
 	const handleRemove = () => {
 		rulesStore.initRemoveConfirm([ruleId]);
@@ -65,6 +71,10 @@ export const RulesItemControls = memo<RulesItemControlsProps>((props) => {
 
 			<TextButton className={styles.control} icon={<EditIcon />} onClick={handleEdit}>
 				Edit
+			</TextButton>
+
+			<TextButton className={styles.control} icon={<AddIcon />} onClick={handleClone}>
+				Clone
 			</TextButton>
 
 			<TextButton className={styles.control} icon={<RemoveIcon />} onClick={handleRemove}>

--- a/src/components/rules/RulesItemControls/RulesItemControls.tsx
+++ b/src/components/rules/RulesItemControls/RulesItemControls.tsx
@@ -37,12 +37,12 @@ export const RulesItemControls = memo<RulesItemControlsProps>((props) => {
 		rulesStore.updateRuleActive(ruleId, !ruleIsActive);
 	};
 
-	const handleMove = async () => {
+	const handleMove = async (shift: 1 | -1) => {
 		// TODO in future
 	};
 
-	const handleMoveAbove = () => handleMove();
-	const handleMoveBelow = () => handleMove();
+	const handleMoveAbove = () => handleMove(-1);
+	const handleMoveBelow = () => handleMove(1);
 
 	const handleRemove = () => {
 		rulesStore.initRemoveConfirm([ruleId]);

--- a/src/interfaces/rule.ts
+++ b/src/interfaces/rule.ts
@@ -69,4 +69,7 @@ export interface Rule {
 
 export interface RuleInitialData {
 	filter?: Partial<Rule['filter']>;
+
+	/** When set, compose opens prefilled from this rule (new id, label becomes `Copy of …`); takes precedence over `filter`. */
+	cloneFrom?: Rule;
 }

--- a/src/stores/RulesStore.ts
+++ b/src/stores/RulesStore.ts
@@ -151,6 +151,15 @@ export class RulesStore {
 		this.compose = {shown: true, initialData};
 	}
 
+	@action('showCloneCompose')
+	showCloneCompose(ruleId: string) {
+		const rule = this.getById(ruleId);
+		if (!rule) {
+			return;
+		}
+		this.showCompose({cloneFrom: toJS(rule)});
+	}
+
 	@action('closeCompose')
 	closeCompose() {
 		this.compose = {shown: false};


### PR DESCRIPTION
I really enjoy using this tool and rely on it daily. One feature I’d love to see added is a cloning mechanism that lets us duplicate any existing rule and modify it as needed.

With this PR, I’ve added a new “Clone” option in the rule’s “More” dropdown menu. When selected, it opens the rule editor with all fields prefilled based on the rule being cloned.

https://github.com/user-attachments/assets/44c9a3e6-f0f2-4702-8fca-45cae4232a30

